### PR TITLE
tests: add books module tests fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,15 +43,9 @@ def mock_buchtitelgenerator(mocker: MockFixture) -> Mock:
     mock = mocker.patch(
         # return a list of 5 books to avoid calling online api
         "pufo_twitter_bot.books.randombuch.buchtitelgenerator",
-        return_value=[
-            "Foo",
-            "Bar",
-            "FooFoo",
-            "BarBar",
-            "FooBar"
-        ]
+        return_value=["Foo", "Bar", "FooFoo", "BarBar", "FooBar"],
     )
-    return Mock
+    return mock
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,23 @@ def mock_randomnames_random_authors(mocker: MockFixture) -> Mock:
 
 
 @pytest.fixture
+def mock_buchtitelgenerator(mocker: MockFixture) -> Mock:
+    """Fixture for mocking books.randombuch.buchtitelgenerator."""
+    mock = mocker.patch(
+        # return a list of 5 books to avoid calling online api
+        "pufo_twitter_bot.books.randombuch.buchtitelgenerator",
+        return_value=[
+            "Foo",
+            "Bar",
+            "FooFoo",
+            "BarBar",
+            "FooBar"
+        ]
+    )
+    return Mock
+
+
+@pytest.fixture
 def mock_tweepy_api(mocker: MockFixture) -> Mock:
     """Fixture for mocking tweepy.api object."""
     return mocker.patch.object(tweepy, "API", autospec=True)

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -15,6 +15,12 @@ def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator: Mock) -> None:
     assert isinstance(books, list)
 
 
+def test_buchtitelgenerator_returns_mocked_books(mock_buchtitelgenerator: Mock) -> None:
+    """It returns a list."""
+    books = randombuch.buchtitelgenerator()
+    assert "Foo" in books
+
+
 def test_buchtitelgenerator_returns_list_of_strs(mock_buchtitelgenerator: Mock) -> None:
     """Each book is of type str."""
     books = randombuch.buchtitelgenerator()

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -9,13 +9,13 @@ import requests
 from pufo_twitter_bot.books import randombuch
 
 
-def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator) -> None:
+def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator: Mock) -> None:
     """It returns a list."""
     books = randombuch.buchtitelgenerator()
     assert isinstance(books, list)
 
 
-def test_buchtitelgenerator_returns_list_of_strs(mock_buchtitelgenerator) -> None:
+def test_buchtitelgenerator_returns_list_of_strs(mock_buchtitelgenerator: Mock) -> None:
     """Each book is of type str."""
     books = randombuch.buchtitelgenerator()
     for book in books:

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -9,13 +9,13 @@ import requests
 from pufo_twitter_bot.books import randombuch
 
 
-def test_buchtitelgenerator_returns_list() -> None:
+def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator) -> None:
     """It returns a list."""
     books = randombuch.buchtitelgenerator()
     assert isinstance(books, list)
 
 
-def test_buchtitelgenerator_returns_list_of_strs() -> None:
+def test_buchtitelgenerator_returns_list_of_strs(mock_buchtitelgenerator) -> None:
     """Each book is of type str."""
     books = randombuch.buchtitelgenerator()
     for book in books:


### PR DESCRIPTION
This will avoid to call a foreign API when running tests.