### PR TITLE
refactor: set API keys implicitly

### DIFF
--- a/src/pufo_twitter_bot/bot/twitter.py
+++ b/src/pufo_twitter_bot/bot/twitter.py
@@ -23,12 +23,6 @@ class TwitterBot:
             tweet (str): The text to tweet.
         """
         self.tweet = tweet
-        (
-            self.consumer_key,
-            self.consumer_secret,
-            self.access_token,
-            self.access_token_secret,
-        ) = self._retrieve_keys()
         self.api = self.create_api()
 
     @property
@@ -50,12 +44,12 @@ class TwitterBot:
         Returns:
             Tuple[str]: Returns the environments variables (can be None type)
         """
-        consumer_key = os.getenv("CONSUMER_KEY")
-        consumer_secret = os.getenv("CONSUMER_SECRET")
-        access_token = os.getenv("ACCESS_TOKEN")
-        access_token_secret = os.getenv("ACCESS_TOKEN_SECRET")
+        self.consumer_key = os.getenv("CONSUMER_KEY")
+        self.consumer_secret = os.getenv("CONSUMER_SECRET")
+        self.access_token = os.getenv("ACCESS_TOKEN")
+        self.access_token_secret = os.getenv("ACCESS_TOKEN_SECRET")
 
-        return consumer_key, consumer_secret, access_token, access_token_secret
+        return self
 
     def create_api(self) -> API:
         """Creates the tweepy API object.
@@ -66,6 +60,9 @@ class TwitterBot:
         Returns:
             API: Returns tweepy API object.
         """
+        # Get all API keys from ENV variables
+        self._retrieve_keys()
+
         auth = tweepy.OAuthHandler(self.consumer_key, self.consumer_secret)
         auth.set_access_token(self.access_token, self.access_token_secret)
         api = tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)

--- a/src/pufo_twitter_bot/bot/twitter.py
+++ b/src/pufo_twitter_bot/bot/twitter.py
@@ -1,12 +1,14 @@
 """The twitter functionalities of pufo-twitter-bot."""
 import os
 from typing import Any
-from typing import Optional
-from typing import Tuple
+from typing import TypeVar
 
 import click
 import tweepy  # type: ignore
 from tweepy.api import API  # type: ignore
+
+
+TwitterBot = TypeVar("TwitterBot")
 
 
 class TwitterBot:
@@ -38,11 +40,11 @@ class TwitterBot:
 
     def _retrieve_keys(
         self,
-    ) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    ) -> TwitterBot:
         """Helper function to retrieve the OS environment variables.
 
         Returns:
-            Tuple[str]: Returns the environments variables (can be None type)
+            TwitterBot: Returns self.
         """
         self.consumer_key = os.getenv("CONSUMER_KEY")
         self.consumer_secret = os.getenv("CONSUMER_SECRET")

--- a/src/pufo_twitter_bot/bot/twitter.py
+++ b/src/pufo_twitter_bot/bot/twitter.py
@@ -1,4 +1,6 @@
 """The twitter functionalities of pufo-twitter-bot."""
+from __future__ import annotations
+
 import os
 from typing import Any
 from typing import TypeVar
@@ -6,9 +8,6 @@ from typing import TypeVar
 import click
 import tweepy  # type: ignore
 from tweepy.api import API  # type: ignore
-
-
-TwitterBot = TypeVar("TwitterBot")
 
 
 class TwitterBot:

--- a/src/pufo_twitter_bot/bot/twitter.py
+++ b/src/pufo_twitter_bot/bot/twitter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 from typing import Any
-from typing import TypeVar
 
 import click
 import tweepy  # type: ignore


### PR DESCRIPTION
API keys should be set implicitly when the API instance is created. This PR will fix this.

Also adds a TypeVar for twitter bot for mypy passing.