### PR TITLE
fix: adjust scraper to new structure of buchtitelgenerator

### DIFF
--- a/src/pufo_twitter_bot/authors/randomnames.py
+++ b/src/pufo_twitter_bot/authors/randomnames.py
@@ -94,4 +94,4 @@ def random_authors(count: int = 10, gender: str = "a") -> AuthorList:
 
     except (requests.RequestException, marshmallow.ValidationError) as error:
         message = str(error)
-        raise click.ClickException(message)
+        raise click.ClickException(message) from error

--- a/src/pufo_twitter_bot/books/randombuch.py
+++ b/src/pufo_twitter_bot/books/randombuch.py
@@ -6,7 +6,8 @@ import requests
 from bs4 import BeautifulSoup  # type: ignore
 
 
-BOOK_URL = "https://www.buchtitelgenerator.de/"
+# BOOK_URL = "https://www.buchtitelgenerator.de/"
+BOOK_URL = "https://buchtitelgenerator.de/generator/"
 
 
 def buchtitelgenerator() -> List[str]:
@@ -24,9 +25,14 @@ def buchtitelgenerator() -> List[str]:
             content = response.content
 
             soup = BeautifulSoup(content, "html.parser")
-            books = soup.find_all("div", class_="panel-heading")
+            
+            # As of November 2022 the site got slight changes that
+            # return a list of paragraphs, the two last ones are empty HTML p-tags
+            container = soup.find("div", class_="entry clr")
+            paragraphs = container.find_all("p")
+            books = [book.text for book in paragraphs[:5]]
 
-            return [book.text.strip() for book in books]
+            return [book.strip() for book in books]
 
     except requests.RequestException as error:
         message = str(error)

--- a/src/pufo_twitter_bot/books/randombuch.py
+++ b/src/pufo_twitter_bot/books/randombuch.py
@@ -25,15 +25,16 @@ def buchtitelgenerator() -> List[str]:
             content = response.content
 
             soup = BeautifulSoup(content, "html.parser")
-            
-            # As of November 2022 the site got slight changes that
-            # return a list of paragraphs, the two last ones are empty HTML p-tags
+
+            # As of November 2022 the site got slight changes that now
+            # returns a list of paragraphs, the two last ones are empty HTML p-tags
             container = soup.find("div", class_="entry clr")
             paragraphs = container.find_all("p")
+            # Only first five entries
             books = [book.text for book in paragraphs[:5]]
 
             return [book.strip() for book in books]
 
     except requests.RequestException as error:
         message = str(error)
-        raise click.ClickException(message)
+        raise click.ClickException(message) from error

--- a/src/pufo_twitter_bot/bot/twitter.py
+++ b/src/pufo_twitter_bot/bot/twitter.py
@@ -70,7 +70,7 @@ class TwitterBot:
             api.verify_credentials()
         except tweepy.error.TweepError as error:
             message = str(error)
-            raise click.ClickException(message)
+            raise click.ClickException(message) from error
         click.echo("tweepy api created")
         return api
 

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -16,7 +16,7 @@ def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator: Mock) -> None:
 
 
 def test_buchtitelgenerator_returns_mocked_books(mock_buchtitelgenerator: Mock) -> None:
-    """'Foo' is part of books."""
+    """The 'Foo' book is part of books."""
     books = randombuch.buchtitelgenerator()
     assert "Foo" in books
 
@@ -39,4 +39,4 @@ def test_buchtitelgenerator_raises(mock_get: Mock) -> None:
 def test_buchtitel_generator() -> None:
     """Books is a non-empty list."""
     books = randombuch.buchtitelgenerator()
-    assert not(len(books) == 0)
+    assert not (len(books) == 0)

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -16,7 +16,7 @@ def test_buchtitelgenerator_returns_list(mock_buchtitelgenerator: Mock) -> None:
 
 
 def test_buchtitelgenerator_returns_mocked_books(mock_buchtitelgenerator: Mock) -> None:
-    """It returns a list."""
+    """'Foo' is part of books."""
     books = randombuch.buchtitelgenerator()
     assert "Foo" in books
 
@@ -34,3 +34,9 @@ def test_buchtitelgenerator_raises(mock_get: Mock) -> None:
     mock_get.side_effect = requests.RequestException
     with pytest.raises(click.ClickException):
         randombuch.buchtitelgenerator()
+
+
+def test_buchtitel_generator() -> None:
+    """Books is a non-empty list."""
+    books = randombuch.buchtitelgenerator()
+    assert not(len(books) == 0)


### PR DESCRIPTION
The scraper failed since the changes to the buchtitel generator site.
This fixes the scraper and allows the tool to run without problems